### PR TITLE
include information about usage of auth parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ These are the available config options for making requests. Only the `url` is re
   // `auth` indicates that HTTP Basic auth should be used, and supplies credentials.
   // This will set an `Authorization` header, overwriting any existing
   // `Authorization` custom headers you have set using `headers`.
+  // Please note that only HTTP Basic auth is configurable through this parameter.
+  // For Bearer tokens and such, use `Authorization` custom headers instead.
   auth: {
     username: 'janedoe',
     password: 's00pers3cret'


### PR DESCRIPTION
Fixes 2158

This pull request adds additional information to the `Readme.md`. I took the liberty to points users who want to use Bearer tokens towards custom authorization headers.